### PR TITLE
Handle updates from BSS

### DIFF
--- a/src/connection-settings-manager.ts
+++ b/src/connection-settings-manager.ts
@@ -140,9 +140,10 @@ export class ConnectionSettingsManager extends Signaler {
      * @param password The password of the network
      * @returns Promise of the new connection profile's path
      */
-    public addWifiWpaConnection(ssid: string, hidden: boolean, password?: string): Promise<ConnectionProfilePath> {
+    public addWifiWpaConnection(ssid: string, hidden: boolean, password?: string, mode?: string, keyMgmt?: string): Promise<ConnectionProfilePath> {
         let connectionProfile: DeepPartial<ConnectionProfile> = {
             connection: {
+                autoconnect: new Variant('b', false),
                 type: new Variant('s', '802-11-wireless'),
                 'interface-name': new Variant('s', 'wlan0'),
                 uuid: new Variant('s', uuidv4()),
@@ -150,7 +151,7 @@ export class ConnectionSettingsManager extends Signaler {
             },
             '802-11-wireless': {
                 ssid: new Variant('ay', stringToByteArray(ssid)),
-                mode: new Variant('s', 'infrastructure'),
+                mode: new Variant('s', mode ? mode : 'infrastructure'),
             },
             ipv4: {
                 method: new Variant('s', 'auto'),
@@ -162,7 +163,7 @@ export class ConnectionSettingsManager extends Signaler {
 
         if (password) {
             connectionProfile['802-11-wireless-security'] = {
-                'key-mgmt': new Variant('s', 'wpa-psk'),
+                'key-mgmt': new Variant('s', keyMgmt ? keyMgmt : 'wpa-psk'),
                 'auth-alg': new Variant('s', 'open'),
                 psk: new Variant('s', password),
             };

--- a/src/dbus-types.ts
+++ b/src/dbus-types.ts
@@ -672,6 +672,61 @@ export interface AccessPointProperties extends Omit<RawAccessPointProperties, 'S
     Ssid: Variant<string>;
 }
 
+export interface WpaSupplicantProperties extends Properties {
+    /**
+     * Flags describing the capabilities of the access point.
+     *
+     * @see AccessPointFlags
+     * */
+    SSID: Variant<number[]>;
+
+    /**
+     * Flags describing the access point's capabilities according to WPA (Wifi Protected Access).
+     *
+     * @see AccessPointSecurityFlags
+     * */
+    BSSID: Variant<number[]>;
+
+    /**
+     * Flags describing the access point's capabilities according to the RSN (Robust Secure Network) protocol.
+     *
+     * @see AccessPointSecurityFlags
+     *  */
+    Privacy: Variant<boolean>;
+
+    /** The Service Set Identifier identifying the access point. */
+    Mode: Variant<string>;
+
+    /** The radio channel frequency in use by the access point, in MHz. */
+    Signal: Variant<number>;
+
+    /** The hardware address (BSSID) of the access point. */
+    Frequency: Variant<number>;
+
+    /** Describes the operating mode of the access point. */
+    Rates: Variant<number[]>;
+
+    //Returns: NM80211Mode
+    /** The maximum bitrate this access point is capable of, in kilobits/second (Kb/s). */
+    KeyMgmt: Variant<string[]>;
+
+    /** The current signal quality of the access point, in percent. */
+    Group: Variant<string>;
+
+    /** The timestamp (in CLOCK_BOOTTIME seconds) for the last time the access point was found in scan results. A value of -1 means the access point has never been found in scan results. */
+    Pairwise: Variant<string[]>;
+
+    MgmtGroup: Variant<string>;
+
+    Age: Variant<number>;
+
+    IEs: Variant<number[]>;
+
+    WPA: Variant<any>;
+    RSN: Variant<any>;
+    WPS: Variant<any>;
+}
+
 /**
  * Properties for the NetworkManager
  * @see https://developer.gnome.org/NetworkManager/stable/gdbus-org.freedesktop.NetworkManager.html
@@ -777,6 +832,7 @@ export interface NetworkManagerProperties extends Properties {
 export interface ConnectionProfile {
     /** https://developer.gnome.org/NetworkManager/stable/settings-connection.html */
     connection: {
+        autoconnect: Variant<boolean>;
         id: Variant<string>;
         'interface-name': Variant<string>;
         type: Variant<'802-11-wireless' | '802-3-ethernet'>;

--- a/src/util.ts
+++ b/src/util.ts
@@ -16,13 +16,13 @@ export async function objectInterface(
     }
 }
 
-export function signal<T extends Array<any> = any[]>(
+export function signal<T extends any[] = any[]>(
     objectInterface: DBus.ClientInterface,
     signalName: string,
 ): Observable<T> {
     return new Observable<T>((observer) => {
-        const listener = (...args: T) => {
-            observer.next(args);
+        const listener = (...args: any[]) => {
+            observer.next(args as T);
         };
 
         objectInterface.on(signalName, listener);
@@ -128,4 +128,10 @@ export function formatIp4Address(ipAddress: number) {
     const byteArray = int32ToByteArray(ipAddress);
 
     return byteArray.reverse().join('.');
+}
+
+export function formatMacAddress(macAddress: number[]): string {
+    const hexStrings = Array.from(macAddress).map(num => num.toString(16).padStart(2, '0'));
+
+    return hexStrings.join(':').toUpperCase();
 }

--- a/src/wifi-device.ts
+++ b/src/wifi-device.ts
@@ -2,23 +2,106 @@ import DBus from '@astrohaus/dbus-next';
 import { BehaviorSubject } from 'rxjs';
 import { Observable } from 'rxjs/internal/Observable';
 import { BaseDevice } from './base-device';
+import { promises as fs } from 'fs';
 import {
     AccessPointProperties,
     ConnectionProfilePath,
     RawAccessPointProperties,
     WifiDeviceProperties,
+    WpaSupplicantProperties,
 } from './dbus-types';
-import { byteArrayToString, call, getAllProperties, objectInterface, signal } from './util';
+import { byteArrayToString, formatMacAddress, call, getAllProperties, getProperty, objectInterface, signal } from './util';
 
 type AccessPointMap = {
     [key: string]: AccessPointProperties;
 };
 
+/* https://github.com/lcp/NetworkManager/blob/240f47c892b4e935a3e92fc09eb15163d1fa28d8/src/nm-wifi-ap.c#L357-L419 */
+export class NM80211ApSecurityFlags {
+    static readonly NM_802_11_AP_SEC_NONE = 0x00000000;
+    static readonly NM_802_11_AP_SEC_PAIR_WEP40 = 0x00000001;
+    static readonly NM_802_11_AP_SEC_PAIR_WEP104 = 0x00000002;
+    static readonly NM_802_11_AP_SEC_PAIR_TKIP = 0x00000004;
+    static readonly NM_802_11_AP_SEC_PAIR_CCMP = 0x00000008;
+    static readonly NM_802_11_AP_SEC_GROUP_WEP40 = 0x00000010;
+    static readonly NM_802_11_AP_SEC_GROUP_WEP104 = 0x00000020;
+    static readonly NM_802_11_AP_SEC_GROUP_TKIP = 0x00000040;
+    static readonly NM_802_11_AP_SEC_GROUP_CCMP = 0x00000080;
+    static readonly NM_802_11_AP_SEC_KEY_MGMT_PSK = 0x00000100;
+    static readonly NM_802_11_AP_SEC_KEY_MGMT_802_1X = 0x00000200;
+    static readonly NM_802_11_AP_SEC_KEY_MGMT_SAE = 0x00000400;
+    static readonly NM_802_11_AP_SEC_KEY_MGMT_OWE = 0x00000800;
+    static readonly NM_802_11_AP_SEC_KEY_MGMT_OWE_TM = 0x00001000;
+    static readonly NM_802_11_AP_SEC_KEY_MGMT_EAP_SUITE_B_192 = 0x00002000;
+
+    private static pairToFlags(str: string): number {
+        switch (str) {
+            case 'wep40': return NM80211ApSecurityFlags.NM_802_11_AP_SEC_PAIR_WEP40;
+            case 'wep104': return NM80211ApSecurityFlags.NM_802_11_AP_SEC_PAIR_WEP104;
+            case 'tkip': return NM80211ApSecurityFlags.NM_802_11_AP_SEC_PAIR_TKIP;
+            case 'ccmp': return NM80211ApSecurityFlags.NM_802_11_AP_SEC_PAIR_CCMP;
+            default: return NM80211ApSecurityFlags.NM_802_11_AP_SEC_NONE;
+        }
+    }
+    
+    private static groupToFlags(str: string): number {
+        switch (str) {
+            case 'wep40': return NM80211ApSecurityFlags.NM_802_11_AP_SEC_GROUP_WEP40;
+            case 'wep104': return NM80211ApSecurityFlags.NM_802_11_AP_SEC_GROUP_WEP104;
+            case 'tkip': return NM80211ApSecurityFlags.NM_802_11_AP_SEC_GROUP_TKIP;
+            case 'ccmp': return NM80211ApSecurityFlags.NM_802_11_AP_SEC_GROUP_CCMP;
+            default: return NM80211ApSecurityFlags.NM_802_11_AP_SEC_NONE;
+        }
+    }
+    
+    private static keyMgmtToFlags(str: string): number {
+        switch (str) {
+            case 'wpa-psk': return NM80211ApSecurityFlags.NM_802_11_AP_SEC_KEY_MGMT_PSK;
+            case 'wpa-eap': return NM80211ApSecurityFlags.NM_802_11_AP_SEC_KEY_MGMT_802_1X;
+            case 'sae': return NM80211ApSecurityFlags.NM_802_11_AP_SEC_KEY_MGMT_SAE;
+            case 'owe': return NM80211ApSecurityFlags.NM_802_11_AP_SEC_KEY_MGMT_OWE;
+            case 'owe-tm': return NM80211ApSecurityFlags.NM_802_11_AP_SEC_KEY_MGMT_OWE_TM;
+            case 'wpa-eap-suite-b-192': return NM80211ApSecurityFlags.NM_802_11_AP_SEC_KEY_MGMT_EAP_SUITE_B_192;
+            default: return NM80211ApSecurityFlags.NM_802_11_AP_SEC_NONE;
+        }
+    }
+
+    static securityFromDict(security: { [key: string]: any }): number {
+        let flags = NM80211ApSecurityFlags.NM_802_11_AP_SEC_NONE;
+
+        if (security.KeyMgmt) {
+            const keyMgmtItems: string[] = security.KeyMgmt.value;
+            keyMgmtItems.forEach(item => {
+                flags |= NM80211ApSecurityFlags.keyMgmtToFlags(item);
+            });
+        }
+
+        if (security.Pairwise) {
+            const pairwiseItems: string[] = security.Pairwise.value;
+            pairwiseItems.forEach(item => {
+                flags |= NM80211ApSecurityFlags.pairToFlags(item);
+            });
+        }
+
+        if (security.Group) {
+            const groupItem: string = security.Group.value;
+            flags |= NM80211ApSecurityFlags.groupToFlags(groupItem);
+        }
+
+        return flags;
+    }
+}
+
 export class WifiDevice extends BaseDevice<WifiDeviceProperties> {
     private _wifiDeviceInterface: DBus.ClientInterface;
+    private _wpaInterface: DBus.ClientInterface;
 
     private _accessPoints: AccessPointMap;
     private _accessPointsSubject: BehaviorSubject<AccessPointMap>;
+    private _bssListeners: Map<string, any>;
+    private _bssPathMap: Map<string, string>;
+    private _accessPointPathMap: Map<string, string>;
+    private _bssInterfaces: Map<string, DBus.ClientInterface>;
 
     /**
      * Continuously updated map of access points
@@ -38,9 +121,13 @@ export class WifiDevice extends BaseDevice<WifiDeviceProperties> {
         devicePath: string,
         deviceInterface: DBus.ClientInterface,
         wifiDeviceInterface: DBus.ClientInterface,
+        wpaInterface: DBus.ClientInterface,
         propertiesInterface: DBus.ClientInterface,
         initialProperties: any,
         initialAccessPoints: AccessPointMap,
+        initialBssPathMap: Map<string, string>,
+        initialAccessPointPathMap: Map<string, string>,
+        initialBssInterfaces: Map<string, DBus.ClientInterface>
     ) {
         super(bus, devicePath, deviceInterface, propertiesInterface, initialProperties);
 
@@ -50,6 +137,14 @@ export class WifiDevice extends BaseDevice<WifiDeviceProperties> {
         this._accessPointsSubject = new BehaviorSubject<AccessPointMap>(this._accessPoints);
         this.accessPoints$ = this._accessPointsSubject.asObservable();
 
+        this._bssListeners = new Map();
+
+        this._wpaInterface = wpaInterface;
+        this._bssPathMap = initialBssPathMap;
+        this._accessPointPathMap = initialAccessPointPathMap;
+        this._bssInterfaces = initialBssInterfaces;
+
+        this._listenForBss();
         this._listenForAccessPoints();
     }
 
@@ -72,6 +167,9 @@ export class WifiDevice extends BaseDevice<WifiDeviceProperties> {
             } = await BaseDevice._init(bus, devicePath, 'org.freedesktop.NetworkManager.Device.Wireless');
 
             const initialAccessPoints: AccessPointMap = {};
+            const initialBssPathMap: Map<string, string> = new Map();
+            const initialAccessPointPathMap: Map<string, string> = new Map();
+            const initialBssInterfaces: Map<string, DBus.ClientInterface> = new Map();
 
             const getAccessPointDataFromPaths = async () => {
                 const accessPoints = wifiDeviceProperties.AccessPoints.value;
@@ -86,9 +184,33 @@ export class WifiDevice extends BaseDevice<WifiDeviceProperties> {
                     let accessPointProperties = await getAllProperties(accessPointInterface);
                     accessPointProperties.Ssid.value = byteArrayToString(accessPointProperties.Ssid.value);
                     initialAccessPoints[accessPointPath] = accessPointProperties as AccessPointProperties;
+                    let bssid = accessPointProperties.HwAddress.value;
+                    initialAccessPointPathMap.set(bssid, accessPointPath);
+                    initialAccessPointPathMap.set(accessPointPath, bssid);
                 }
             };
 
+            const getBSSs = async() => {
+                const bss = await getProperty(wpaInterface, 'BSSs')
+        
+                for (let i = 0; i < bss.value.length; i++) {
+                    let bssPath = bss.value[i];
+                    let bssObject = await bus.getProxyObject('fi.w1.wpa_supplicant1', bssPath);
+                    let bssInterface = await bssObject.getInterface('fi.w1.wpa_supplicant1.BSS');
+                    let bssidArray = await getProperty(bssInterface, 'BSSID') as DBus.Variant<number[]>;
+                    let bssid = formatMacAddress(bssidArray.value);
+                    initialBssPathMap.set(bssid, bssPath);
+                    initialBssPathMap.set(bssPath, bssid);
+                    initialBssInterfaces.set(bssid, bssInterface);
+                }
+            };
+
+            const interfaceNum = 0; // hardcode interface number to "0"
+            const wpaPath = `/fi/w1/wpa_supplicant1/Interfaces/${interfaceNum}`
+            const wpaObject = await bus.getProxyObject('fi.w1.wpa_supplicant1', wpaPath);
+            const wpaInterface = await wpaObject.getInterface('fi.w1.wpa_supplicant1.Interface')
+    
+            await getBSSs();
             await getAccessPointDataFromPaths();
 
             return new WifiDevice(
@@ -96,9 +218,13 @@ export class WifiDevice extends BaseDevice<WifiDeviceProperties> {
                 devicePath,
                 deviceInterface,
                 wifiDeviceInterface,
+                wpaInterface,
                 propertiesInterface,
                 initialProperties,
                 initialAccessPoints,
+                initialBssPathMap,
+                initialAccessPointPathMap,
+                initialBssInterfaces
             );
         } catch (error) {
             throw `Error creating wifi device: ${error}`;
@@ -164,9 +290,14 @@ export class WifiDevice extends BaseDevice<WifiDeviceProperties> {
                     },
                 };
 
+                const bssid = rawAccessPointProperties.HwAddress.value;
+                this._accessPointPathMap.set(bssid, apPath);
+                this._accessPointPathMap.set(apPath, bssid);
+
                 this._accessPoints = { ...this._accessPoints, [apPath]: accessPointProperties };
                 this._accessPointsSubject.next(this._accessPoints);
-            } catch (_) {
+            } catch (error) {
+                console.error(`ERROR: ${error}`);
                 // If we can't find an access point's data, skip over it
             }
         });
@@ -175,8 +306,97 @@ export class WifiDevice extends BaseDevice<WifiDeviceProperties> {
             const apPath = params[0];
             const { [apPath]: deletedAp, ...filteredAccessPoints } = this._accessPoints;
 
+            const bssid = this._accessPointPathMap.get(apPath);
+            this._accessPointPathMap.delete(apPath);
+            if (bssid !== undefined) {
+                this._accessPointPathMap.delete(bssid);
+            }
+
             this._accessPoints = filteredAccessPoints;
             this._accessPointsSubject.next(this._accessPoints);
         });
+    }
+
+    private _listenForBss() {
+        this.listenSignal<Partial<WpaSupplicantProperties>[]>(this._wpaInterface, 'BSSAdded', async (params: any[]) => {
+            const bssPath = params[0];
+            const bssid = formatMacAddress(params[1].BSSID.value);
+            try {
+                const bssObject = await this._bus.getProxyObject('fi.w1.wpa_supplicant1', bssPath);
+                const bssInterface = await bssObject.getInterface('fi.w1.wpa_supplicant1.BSS');
+                this._bssInterfaces.set(bssid, bssInterface);
+                this._bssPathMap.set(bssid, bssPath);
+                this._bssPathMap.set(bssPath, bssid);
+    
+                this._listenForBssPropertyChanges(bssid);
+            } catch (error) {
+                console.error(`BSSAdded signal handler ERROR: ${error}`);
+                return;
+            }
+        });
+        this.listenSignal(this._wpaInterface, 'BSSRemoved', async (params: any[]) => {
+            const bssPath = params[0];
+            const bssid = this._bssPathMap.get(bssPath);
+            this._bssPathMap.delete(bssPath);
+            if (bssid !== undefined) {
+                this._bssPathMap.delete(bssid);
+            }
+            const listenerRef = this._bssListeners.get(bssPath);
+            if (listenerRef) {
+                listenerRef.unsubscribe();
+                this._bssListeners.delete(bssPath);
+            }
+        });
+        for (const bssid of this._bssInterfaces.keys()) {
+            this._listenForBssPropertyChanges(bssid);
+        }
+    }
+
+    private _listenForBssPropertyChanges(bssid: string) {
+        const bssInterface = this._bssInterfaces.get(bssid);
+        if (bssInterface === undefined) {
+            return;
+        }
+        const listenerRef = this.listenSignal<Partial<WpaSupplicantProperties>[]>(
+            bssInterface,
+            'PropertiesChanged',
+            async (params: any[]) => {
+                const bssPath = this._bssPathMap.get(bssid);
+                if (bssPath === undefined) {
+                    console.error(`bssPath not found for ${bssid}`);
+                    return;
+                }
+                const apPath = this._accessPointPathMap.get(bssid);
+                if (apPath === undefined) {
+                    console.error(`apPath not found for ${bssid}`);
+                    return;
+                }
+                const props = this._accessPoints[apPath];
+                if (params[0].Age !== undefined) {
+                    props.LastSeen.value = (await this._getUptime()) + params[0].Age.value;
+                }
+                if (params[0].Frequency !== undefined) {
+                    props.Frequency.value = params[0].Frequency.value;
+                }
+                if (params[0].WPA !== undefined) {
+                    props.WpaFlags.value = NM80211ApSecurityFlags.securityFromDict(params[0].WPA.value);
+                }
+                if (params[0].RSN !== undefined) {
+                    props.RsnFlags.value = NM80211ApSecurityFlags.securityFromDict(params[0].RSN.value);
+                }
+            }
+        );
+        this._bssListeners.set(bssid, listenerRef);
+    }
+
+    private async _getUptime(): Promise<number> {
+        try {
+            const data = await fs.readFile('/proc/uptime', 'utf8');
+            const uptimeSeconds = parseInt(data.split(' ')[0]);
+            return uptimeSeconds;
+        } catch (error) {
+            console.error('Error reading uptime:', error);
+            throw error;
+        }
     }
 }


### PR DESCRIPTION
This change introduces handling updates from WpaSupplicant BSS events.
This is useful in case if announced AccessPoint has changed some of it's properties. Those changes are propagated only via BSS interface.

Also introducing extra parameters to specify `mode` (infrastructure|ap) and `keyMgmt`.